### PR TITLE
Remove hostName production

### DIFF
--- a/templates/nginx-ingress-tls.yaml
+++ b/templates/nginx-ingress-tls.yaml
@@ -33,13 +33,4 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-    {{- if eq .Values.environment "production" }}
-    - host: {{ .Values.hostnameProduction }}
-      http:
-        paths:
-          - path: /{{ .Values.hostpathProduction | default .Values.hostpath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-    {{- end }}
 {{- end }}

--- a/templates/nginx-ingress.yaml
+++ b/templates/nginx-ingress.yaml
@@ -36,13 +36,4 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-    {{- if eq .Values.environment "production" }}
-    - host: {{ .Values.hostnameProduction }}
-      http:
-        paths:
-          - path: /{{ .Values.hostpathProduction | default .Values.hostpath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-    {{- end }}
 {{- end }}


### PR DESCRIPTION
This ignores the master.k8s.greenpeace.org hostname (hostNameProduction) from being deployed to nginx load balancers

`hostNameProduction` and `hostPathProduction`


This ignores those parameters for nginx ingresses. This means once we migrate to nginx ingress the sites will not be accessible via master.k8s.p4.greenpeace.org/<nro name>. 

Merging this change _at the moment_ will not result in any visible changes as all traffic is still going via traefik. I think it is better to merge this change now so we can test if it will cause any issues before migrating over.

Post migration the chart will have to be cleaned up:
https://github.com/greenpeace/planet4-helm-wordpress/blob/1e5289cf60dfb0f54826dd07766c1da96fc98aef/values.yaml#L11
