### PR TITLE
Increase redis requests

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ redis:
     resources:
       requests:
         memory: 64Mi
-        cpu: 10m
+        cpu: 100m
       limits:
         memory: 256Mi
         cpu: 1
@@ -141,7 +141,7 @@ redis:
     resources:
       requests:
         memory: 64Mi
-        cpu: 10m
+        cpu: 100m
       limits:
         memory: 256Mi
         cpu: 1


### PR DESCRIPTION
Redis is consistently using more than 80m in development and production. We should increase requests to ensure that pods get scheduled appropriately.