### PR TITLE
Update PDB API Version

### DIFF
--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "openresty.fullname" . }}
@@ -10,7 +10,7 @@ spec:
       release: {{ .Release.Name }}
       component: proxy
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "php.fullname" . }}


### PR DESCRIPTION
v1beta1 is deprecated in 1.25 this prepares us for that version.