### PR TITLE
Upgrade compatibility for Helm v3 and add NetworkPolicies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: helm init --client-only
-      - run: helm repo add rimusz https://charts.rimusz.net
-      - run: helm repo add bitnami https://charts.bitnami.com/bitnami
+      - run: helm3 repo add rimusz https://charts.rimusz.net
+      - run: helm3 repo add bitnami https://charts.bitnami.com/bitnami
       - run: activate-gcloud-account.sh
       - run: BUILD_TAG=${CIRCLE_TAG#v} make
 

--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,4 @@ push: package $(CHART_DIRECTORY)
 .PHONY: update
 update:
 	@helm repo update
-	@helm search repo p4 $(CHART_NAME)
+	@helm search p4/$(CHART_NAME)

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ lint-yaml: Chart.yaml requirements.yaml
 
 .PHONY: lint-helm
 lint-helm:
-	@helm lint .
+	@helm3 lint .
 
 .PHONY: dep
 dep: lint
-	@helm dependency update
+	@helm3 dependency update
 
 $(CHART_DIRECTORY):
 	@mkdir -p $@
@@ -86,16 +86,16 @@ package: lint Chart.yaml
 		>&2 echo "ERROR: Refusing to package non-semver release: '$(BUILD_TAG)'"; \
 		exit 1; \
 	}
-	@helm package .
+	@helm3 package .
 	@mv $(CHART_NAME)-*.tgz $(CHART_DIRECTORY)
 
 .PHONY: verify
 verify: lint
-	@helm verify $(CHART_DIRECTORY)
+	@helm3 verify $(CHART_DIRECTORY)
 
 .PHONY: index
 index: lint $(CHART_DIRECTORY)
-	@helm repo index $(CHART_DIRECTORY) --url $(CHART_URL)
+	@helm3 repo index $(CHART_DIRECTORY) --url $(CHART_URL)
 
 .PHONY: push
 push: package $(CHART_DIRECTORY)
@@ -103,5 +103,5 @@ push: package $(CHART_DIRECTORY)
 
 .PHONY: update
 update:
-	@helm repo update
-	@helm search p4/$(CHART_NAME)
+	@helm3 repo update
+	@helm3 search p4/$(CHART_NAME)

--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,4 @@ push: package $(CHART_DIRECTORY)
 .PHONY: update
 update:
 	@helm3 repo update
-	@helm3 search p4/$(CHART_NAME)
+	@helm3 search repo p4/$(CHART_NAME)

--- a/requirements.lock
+++ b/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.6.13
-digest: sha256:0a1ead80ed2538b8a50b98032549efa4b14883edfb6fcfb7b68733c4ebf20425
-generated: "2022-05-20T16:25:06.5444494+02:00"
+digest: sha256:b15c80be33efeef65f46fe365ef7a8d2e772b819a052543b94998ca554721bad
+generated: "2022-05-20T17:26:03.8715019+02:00"

--- a/requirements.lock
+++ b/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.6.13
-digest: sha256:b15c80be33efeef65f46fe365ef7a8d2e772b819a052543b94998ca554721bad
-generated: "2022-02-08T13:45:35.8385228+11:00"
+digest: sha256:0a1ead80ed2538b8a50b98032549efa4b14883edfb6fcfb7b68733c4ebf20425
+generated: "2022-05-20T16:25:06.5444494+02:00"

--- a/templates/network-policy-openresty.yaml
+++ b/templates/network-policy-openresty.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "generic.fullname" . }}-openresty
+  labels:
+    app: "planet4"
+    chart: {{ template "wordpress.chart" . }}
+    environment: {{ .Values.environment | quote }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      component: proxy
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: nginx-ingress
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 80
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+              release: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 6379
+    - to:
+        - podSelector:
+            matchLabels:
+              component: php
+              release: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 80
+---

--- a/templates/network-policy-php.yaml
+++ b/templates/network-policy-php.yaml
@@ -47,7 +47,7 @@ spec:
           port: 3306
     - to:
         - podSelector:
-            matchlabels:
+            matchLabels:
               app: elasticsearch-data
               chart: elasticsearch
               release: p4-es-data
@@ -59,7 +59,7 @@ spec:
           port: 9200
     - to:
         - podSelector:
-            matchlabels:
+            matchLabels:
               app: apm-server
               release: apm
           namespaceSelector:

--- a/templates/network-policy-php.yaml
+++ b/templates/network-policy-php.yaml
@@ -57,4 +57,15 @@ spec:
       ports:
         - protocol: TCP
           port: 9200
+    - to:
+        - podSelector:
+            matchlabels:
+              app: apm-server
+              release: apm
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: elastic
+      ports:
+        - protocol: TCP
+          port: 8200
 ---

--- a/templates/network-policy-php.yaml
+++ b/templates/network-policy-php.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "generic.fullname" . }}-php
+  labels:
+    app: "planet4"
+    chart: {{ template "wordpress.chart" . }}
+    environment: {{ .Values.environment | quote }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      component: php
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+              release: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 80
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+              release: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 6379
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: sqlproxy
+              app.kubernetes.io/name: gcloud-sqlproxy
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: sqlproxy
+      ports:
+        - protocol: TCP
+          port: 3306
+    - to:
+        - podSelector:
+            matchlabels:
+              app: elasticsearch-data
+              chart: elasticsearch
+              release: p4-es-data
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: elastic
+      ports:
+        - protocol: TCP
+          port: 9200
+---

--- a/templates/network-policy-redis.yaml
+++ b/templates/network-policy-redis.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "generic.fullname" . }}-redis
+  labels:
+    app: "planet4"
+    chart: {{ template "wordpress.chart" . }}
+    environment: {{ .Values.environment | quote }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+              release: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 6379
+    - from:
+        - podSelector:
+            matchLabels:
+              component: php
+              release: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 6379
+---

--- a/templates/probe.yaml
+++ b/templates/probe.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ template "generic.fullname" . }}
-  release: prometheus-stack
   labels:
     release: prometheus-stack
 spec:


### PR DESCRIPTION
# Upgrade compatibility for Helm v3 and add NetworkPolicies

This PR fixes some syntax issues to support validation with Helmv3. It also add NetworkPolicies for the resources in the Wordpress chart. These will not take effect at the moment because the cluster does not currently support them. But I will look at enabling it in the cluster next Monday.

This should be merged before the changes to planet4-builder: https://github.com/greenpeace/planet4-builder/pull/97