### PR TITLE
Add form data private key

### DIFF
--- a/templates/deployment-php.yaml
+++ b/templates/deployment-php.yaml
@@ -215,6 +215,11 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-keysalt"
                   key: sendgridNroApiKey
+            - name: NRO_FORM_DATA_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-keysalt"
+                  key: nroFormDataPrivateKey
 
           ports:
             - name: fastcgi

--- a/templates/secrets-wp-keysalt.yaml
+++ b/templates/secrets-wp-keysalt.yaml
@@ -25,3 +25,4 @@ data:
     secureAuthSalt: {{ .Values.wp.secureAuthSalt | quote }}
     sendgridApiKey: {{ .Values.sendgridApiKey | quote }}
     sendgridNroApiKey: {{ .Values.sendgridNroApiKey | quote }}
+    nroFormDataPrivateKey: {{ .Values.nroFormDataPrivateKey | quote }}


### PR DESCRIPTION
Add NRO_FORM_DATA_PRIVATE_KEY as an environment variable.

PR 1/3 needed for [issue 193](https://github.com/greenpeace/planet4/issues/193) ([Documentation](https://support.greenpeace.org/planet4/infrastructure/environment-variables)).
Ref: https://github.com/greenpeace/planet4/issues/193